### PR TITLE
Add Dynamic, which proudly uses WC as well!

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ These following libraries integrate WalletConnect
 - [web3-onboard](https://onboard.blocknative.com/)
 - [RainbowKit](https://www.rainbowkit.com/)
 - [ConnectKit](https://docs.family.co/connectkit)
+- [Dynamic](https://www.dynamic.xyz)
 
 # Community SDKs
 


### PR DESCRIPTION
Adding Dynamic, which offers a free multi-chain wallet adapter and also proudly leverages WC (and WC v2!!)